### PR TITLE
Implementation of moving skins up and down the list

### DIFF
--- a/SkinPack.App/Events/ClickEvents.cs
+++ b/SkinPack.App/Events/ClickEvents.cs
@@ -221,11 +221,11 @@ namespace SkinPackCreator.ClickEvents
 
             if (index < 1 && Global.Skins.SkinList.Count >= 2)
             {
-                MessageBox.Show("The selected skin is not able to move further up!");
+                MessageBox.Show("The selected skin is not able to move further up!", "Alert", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else if (Global.Skins.SkinList.Count <= 1)
             {
-                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin up!");
+                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin up!", "Alert", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else
             {
@@ -249,11 +249,11 @@ namespace SkinPackCreator.ClickEvents
 
             if (Global.Skins.SkinList.Count <= 1)
             {
-                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin down!");
+                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin down!", "Alert", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else if (index + 1 == Global.Skins.SkinList.Count)
             {
-                MessageBox.Show("The selected skin is not able to move further down!");
+                MessageBox.Show("The selected skin is not able to move further down!", "Alert", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             else
             {

--- a/SkinPack.App/Events/ClickEvents.cs
+++ b/SkinPack.App/Events/ClickEvents.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Windows.Forms;
 using FileProcessing = SkinPackCreator.FileProcessing;
 using FolderProcessing = SkinPackCreator.FolderProcessing;
@@ -214,6 +214,62 @@ namespace SkinPackCreator.ClickEvents
 
             FileProcessing.FillSkinsList(form);
             Utils.SelectNextListItem(form, index);
+        }
+        public void MoveUp(Form1 form)
+        {
+            var index = form.Get_SkinListSelectedIndex();
+
+            if (index < 1 && Global.Skins.SkinList.Count >= 2)
+            {
+                MessageBox.Show("The selected skin is not able to move further up!");
+            }
+            else if (Global.Skins.SkinList.Count <= 1)
+            {
+                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin up!");
+            }
+            else
+            {
+                var temp = Global.Skins.SkinList[index];
+
+                Global.Skins.SkinList[index] = Global.Skins.SkinList[index - 1];
+                Global.Skins.SkinList[index - 1] = temp;
+
+                FileProcessing.FillSkinsList(form);
+                Utils.SelectNextListItem(form, index - 1);
+
+                form.Focus_SkinName();
+                form.SelectAll_SkinName();
+
+                form.Set_StatusLabel("Skin moved up!");
+            }
+        }
+        public void MoveDown (Form1 form)
+        {
+            var index = form.Get_SkinListSelectedIndex();
+
+            if (Global.Skins.SkinList.Count <= 1)
+            {
+                MessageBox.Show("You need at least 2 skins to be able to move the currently selected skin down!");
+            }
+            else if (index + 1 == Global.Skins.SkinList.Count)
+            {
+                MessageBox.Show("The selected skin is not able to move further down!");
+            }
+            else
+            {
+                var temp = Global.Skins.SkinList[index];
+
+                Global.Skins.SkinList[index] = Global.Skins.SkinList[index + 1];
+                Global.Skins.SkinList[index + 1] = temp;
+
+                FileProcessing.FillSkinsList(form);
+                Utils.SelectNextListItem(form, index + 1);
+
+                form.Focus_SkinName();
+                form.SelectAll_SkinName();
+
+                form.Set_StatusLabel("Skin moved down!");
+            }
         }
         public void OpenInstalledSkinFolder()
         {

--- a/SkinPack.App/Form1.Designer.cs
+++ b/SkinPack.App/Form1.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace SkinPackCreator
 {
@@ -57,6 +57,8 @@ namespace SkinPackCreator
             this.toolStripStatus = new System.Windows.Forms.ToolStripStatusLabel();
             this.buttonAdd = new System.Windows.Forms.Button();
             this.buttonRemove = new System.Windows.Forms.Button();
+            this.buttonMoveUp = new System.Windows.Forms.Button();
+            this.buttonMoveDown = new System.Windows.Forms.Button();
             this.comboBoxFormat = new System.Windows.Forms.ComboBox();
             this.buttonDonate = new System.Windows.Forms.Button();
             this.buttonImportMultiple = new System.Windows.Forms.Button();
@@ -305,6 +307,26 @@ namespace SkinPackCreator
             this.buttonRemove.Text = "Remove";
             this.buttonRemove.UseVisualStyleBackColor = true;
             this.buttonRemove.Click += new System.EventHandler(this.ButtonRemove_Click);
+            //
+            // buttonMoveUp
+            //
+            this.buttonMoveUp.Location = new System.Drawing.Point(207, 172);
+            this.buttonMoveUp.Name = "buttonMoveUp";
+            this.buttonMoveUp.Size = new System.Drawing.Size(40, 40);
+            this.buttonMoveUp.TabIndex = 50;
+            this.buttonMoveUp.Text = "▲";
+            this.buttonMoveUp.UseVisualStyleBackColor = true;
+            this.buttonMoveUp.Click += new System.EventHandler(this.ButtonMoveUp_Click);
+            //
+            // buttonMoveDown
+            //
+            this.buttonMoveDown.Location = new System.Drawing.Point(207, 222);
+            this.buttonMoveDown.Name = "buttonMoveDown";
+            this.buttonMoveDown.Size = new System.Drawing.Size(40, 40);
+            this.buttonMoveDown.TabIndex = 60;
+            this.buttonMoveDown.Text = "▼";
+            this.buttonMoveDown.UseVisualStyleBackColor = true;
+            this.buttonMoveDown.Click += new System.EventHandler(this.ButtonMoveDown_Click);
             // 
             // comboBoxFormat
             // 
@@ -358,8 +380,10 @@ namespace SkinPackCreator
             this.Controls.Add(this.buttonImportMultiple);
             this.Controls.Add(this.buttonDonate);
             this.Controls.Add(this.comboBoxFormat);
-            this.Controls.Add(this.buttonRemove);
             this.Controls.Add(this.buttonAdd);
+            this.Controls.Add(this.buttonRemove);
+            this.Controls.Add(this.buttonMoveUp);
+            this.Controls.Add(this.buttonMoveDown);
             this.Controls.Add(this.statusLabel);
             this.Controls.Add(this.pictureBoxSkin);
             this.Controls.Add(this.buttonBrowseSkin);
@@ -375,7 +399,7 @@ namespace SkinPackCreator
             this.Controls.Add(this.listSkins);
             this.Controls.Add(this.menuStripMain);
             this.Name = "Form1";
-            this.Text = "Minecraft Skin Pack Creator for Bedrock Edition - v1.1.1";
+            this.Text = "Minecraft Skin Pack Creator for Bedrock Edition - v1.1.2";
             this.Load += new System.EventHandler(this.Form1_Load);
             this.Resize += new System.EventHandler(this.Form1_Resize);
             this.menuStripMain.ResumeLayout(false);
@@ -411,6 +435,8 @@ namespace SkinPackCreator
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatus;
         private System.Windows.Forms.Button buttonAdd;
         private System.Windows.Forms.Button buttonRemove;
+        private System.Windows.Forms.Button buttonMoveUp;
+        private System.Windows.Forms.Button buttonMoveDown;
         private System.Windows.Forms.ToolStripMenuItem menuSave;
         private System.Windows.Forms.ToolStripMenuItem menuInstall;
         private System.Windows.Forms.TextBox textBoxPackDescription;

--- a/SkinPack.App/Form1.cs
+++ b/SkinPack.App/Form1.cs
@@ -134,7 +134,7 @@ namespace SkinPackCreator
         {
             try
             {
-                if (!IsMcpackCreated(sender, e))
+                if (Global.Skins.SkinList.Count <= 0)
                     return;
 
                 ClickEvents.MoveUp(this);
@@ -148,7 +148,7 @@ namespace SkinPackCreator
         {
             try
             {
-                if (!IsMcpackCreated(sender, e))
+                if (Global.Skins.SkinList.Count <= 0)
                     return;
 
                 ClickEvents.MoveDown(this);

--- a/SkinPack.App/Form1.cs
+++ b/SkinPack.App/Form1.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -124,6 +124,34 @@ namespace SkinPackCreator
                     return;
 
                 ClickEvents.RemoveSkin(this);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        private void ButtonMoveUp_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (Global.Skins.SkinList.Count < 2 && !IsMcpackCreated(sender, e))
+                    return;
+
+                ClickEvents.MoveUp(this);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        private void ButtonMoveDown_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (Global.Skins.SkinList.Count < 2 && !IsMcpackCreated(sender, e))
+                    return;
+
+                ClickEvents.MoveDown(this);
             }
             catch (Exception ex)
             {

--- a/SkinPack.App/Form1.cs
+++ b/SkinPack.App/Form1.cs
@@ -134,7 +134,7 @@ namespace SkinPackCreator
         {
             try
             {
-                if (Global.Skins.SkinList.Count < 2 && !IsMcpackCreated(sender, e))
+                if (!IsMcpackCreated(sender, e))
                     return;
 
                 ClickEvents.MoveUp(this);
@@ -148,7 +148,7 @@ namespace SkinPackCreator
         {
             try
             {
-                if (Global.Skins.SkinList.Count < 2 && !IsMcpackCreated(sender, e))
+                if (!IsMcpackCreated(sender, e))
                     return;
 
                 ClickEvents.MoveDown(this);


### PR DESCRIPTION
Closes #13 

This is my implementation of moving skins up and down for both convenience sake and to close the issue that was open.
With this, people should be able to prioritize which skin goes where, especially considering Bedrocks way of displaying skinpacks ingame does follow the order of the skins.json file.
Merging this change will bump up the version of this program from 1.1.1 to 1.1.2.
Additionally, if one has imported lots of skins, so that one has to actually scroll the list in the MinecraftSkinPackCreator, the scroll view becomes somewhat quirky.
This is not because of this PR, as making the window super small, then creating ~40 entries, then renaming them one after another will show you the same thing.